### PR TITLE
Fix method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can also use an alternative webhook, by specify extra ones in the config fil
 ],
 ```
 
-The webhook to be used can be chosen using the `in` function.
+The webhook to be used can be chosen using the `to` function.
 
 ```php
 use Spatie\SlackAlerts\Facades\SlackAlert;


### PR DESCRIPTION
The README was talking about a nonexistent `in` method instead of the correct `to` one.