### PR TITLE
Make error message consistent with the other ones

### DIFF
--- a/src/Exceptions/JobClassDoesNotExist.php
+++ b/src/Exceptions/JobClassDoesNotExist.php
@@ -8,6 +8,6 @@ class JobClassDoesNotExist extends RunTimeException
 {
     public static function make(?string $name): self
     {
-        return new self("The configured job class `{$name}` does not exist. Make sure you specific a valid class name in the job key of the slack-alerts config file.");
+        return new self("The configured job class `{$name}` does not exist. Make sure you specific a valid class name in the `job` key of the slack-alerts config file.");
     }
 }


### PR DESCRIPTION
Messages in the other exceptions use backticks to surround the configuration key they’re talking about.