### PR TITLE
Ignore also '' as webhook URL, not just NULL ones

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -27,7 +27,7 @@ class Config
 
         $url = config("slack-alerts.webhook_urls.{$name}");
 
-        if (is_null($url)) {
+        if (! $url) {
             return null;
         }
 


### PR DESCRIPTION
in my .env.example is a `SLACK_ALERT_WEBHOOK=` line as a template for new installations, however that currently fails - other than a totally missing line. The intention of the change in 1.1.0 was to make it not fail in local development environments when slack webhooks are not set up, so I think this change that I propose here is a bugfix to 1.1.0 to implement the intended behavior better.