### PR TITLE
Add support to send a set of blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ To send a message to Slack, simply call `SlackAlert::message()` and pass it any 
 SlackAlert::message("You have a new subscriber to the {$newsletter->name} newsletter!");
 ```
 
+## Sending blocks
+
+Slack supports sending rich formatting using their [Block Kit](https://api.slack.com/block-kit) API, you can send a set of blocks using the `blocks()` method:
+
+```php
+SlackAlert::blocks([
+    [
+        "type" => "section",
+        "text" => [
+        "type" => "mrkdwn",
+            "text" => "You have a new subscriber to the {$newsletter->name} newsletter!"
+        ]
+    ]
+]);
+```
+
 ## Using multiple webhooks
 
 You can also use an alternative webhook, by specify extra ones in the config file.

--- a/src/Facades/SlackAlert.php
+++ b/src/Facades/SlackAlert.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static self to(string $text)
  * @method static void message(string $text)
+ * @method static void blocks(array $blocks)
  *
  * @see \Spatie\SlackAlerts\SlackAlert
  */

--- a/src/Jobs/SendToSlackChannelJob.php
+++ b/src/Jobs/SendToSlackChannelJob.php
@@ -22,15 +22,17 @@ class SendToSlackChannelJob implements ShouldQueue
     public int $maxExceptions = 3;
 
     public function __construct(
-        public string $text,
-        public string $type,
-        public string $webhookUrl
+        public string $webhookUrl,
+        public ?string $text = null,
+        public ?array $blocks = null,
     ) {
     }
 
     public function handle(): void
     {
-        $payload = ['type' => $this->type, 'text' => $this->text];
+        $payload = $this->text
+            ? ['type' => 'mrkdwn', 'text' => $this->text]
+            : ['blocks' => $this->blocks];
 
         Http::post($this->webhookUrl, $payload);
     }

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -21,13 +21,26 @@ class SlackAlert
             return;
         }
 
-        $jobArguments = [
+        $job = Config::getJob([
             'text' => $text,
-            'type' => 'mrkdown',
             'webhookUrl' => $webhookUrl,
-        ];
+        ]);
 
-        $job = Config::getJob($jobArguments);
+        dispatch($job);
+    }
+
+    public function blocks(array $blocks): void
+    {
+        $webhookUrl = Config::getWebhookUrl($this->webhookUrlName);
+
+        if (! $webhookUrl) {
+            return;
+        }
+
+        $job = Config::getJob([
+            'blocks' => $blocks,
+            'webhookUrl' => $webhookUrl,
+        ]);
 
         dispatch($job);
     }

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -26,9 +26,9 @@ it('can dispatch a job to send a set of blocks to slack using the default webhoo
             "type" => "section",
             "text" => [
                 "type" => "mrkdwn",
-                "text" => "Hello!"
-            ]
-        ]
+                "text" => "Hello!",
+            ],
+        ],
     ]);
 
     Bus::assertDispatched(SendToSlackChannelJob::class);

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -18,6 +18,22 @@ it('can dispatch a job to send a message to slack using the default webhook url'
     Bus::assertDispatched(SendToSlackChannelJob::class);
 });
 
+it('can dispatch a job to send a set of blocks to slack using the default webhook url', function () {
+    config()->set('slack-alerts.webhook_urls.default', 'https://test-domain.com');
+
+    SlackAlert::blocks([
+        [
+            "type" => "section",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Hello!"
+            ]
+        ]
+    ]);
+
+    Bus::assertDispatched(SendToSlackChannelJob::class);
+});
+
 it('can dispatch a job to send a message to slack using an alternative webhook url', function () {
     config()->set('slack-alerts.webhook_urls.marketing', 'https://test-domain.com');
 


### PR DESCRIPTION
This allows you to send a set of [blocks](https://api.slack.com/block-kit) as a Slack message, which allows for nice formatting