### PR TITLE
Fix SendToSlackChannelJob retry on error

### DIFF
--- a/src/Jobs/SendToSlackChannelJob.php
+++ b/src/Jobs/SendToSlackChannelJob.php
@@ -16,6 +16,8 @@ class SendToSlackChannelJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    public int $tries = 0;
+    
     /**
      * The maximum number of unhandled exceptions to allow before failing.
      */
@@ -34,6 +36,6 @@ class SendToSlackChannelJob implements ShouldQueue
             ? ['type' => 'mrkdwn', 'text' => $this->text]
             : ['blocks' => $this->blocks];
 
-        Http::post($this->webhookUrl, $payload);
+        Http::post($this->webhookUrl, $payload)->throw();
     }
 }


### PR DESCRIPTION
Laravel's HTTP client does not throw client or server exceptions [by default](https://laravel.com/docs/10.x/http-client#error-handling), which means that if one of these errors occurs, the job will not be retried.

For `$maxExceptions` to work, the `$tries` property must also be set to `0` or the value  >= `$maxExceptions`.