### PR TITLE
Add queue support for Slack alerts

### DIFF
--- a/config/slack-alerts.php
+++ b/config/slack-alerts.php
@@ -13,4 +13,5 @@ return [
      * job to set timeouts, retries, etc...
      */
     'job' => Spatie\SlackAlerts\Jobs\SendToSlackChannelJob::class,
+    'queue' => env('SLACK_ALERT_QUEUE', 'default'),
 ];

--- a/src/Config.php
+++ b/src/Config.php
@@ -37,4 +37,15 @@ class Config
 
         return $url;
     }
+
+    public static function getQueue(): string|null
+    {
+        $queue = config('slack-alerts.queue');
+
+        if (! $queue) {
+            return null;
+        }
+
+        return $queue;
+    }
 }

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -7,6 +7,8 @@ class SlackAlert
     protected string $webhookUrlName = 'default';
     protected ?string $channel = null;
 
+    protected ?string $queue = null;
+
     public function to(string $webhookUrlName): self
     {
         $this->webhookUrlName = $webhookUrlName;
@@ -17,6 +19,13 @@ class SlackAlert
     public function toChannel(string $channel): self
     {
         $this->channel = $channel;
+
+        return $this;
+    }
+
+    public function onQueue(string $queue): self
+    {
+        $this->queue = $queue;
 
         return $this;
     }
@@ -35,7 +44,8 @@ class SlackAlert
             'channel' => $this->channel,
         ]);
 
-        dispatch($job);
+        dispatch($job)
+            ->onQueue( $this->queue ?? Config::getQueue() );
     }
 
     public function blocks(array $blocks): void
@@ -52,6 +62,7 @@ class SlackAlert
             'channel' => $this->channel,
         ]);
 
-        dispatch($job);
+        dispatch($job)
+            ->onQueue( $this->queue ?? Config::getQueue() );
     }
 }


### PR DESCRIPTION
First of all, hello to all. This is my first contribution to an open source package, so please go easy on me. I'm not a software engineer, never developed professionally, but I dabble a bit in the Laravel ecosystem every now and then.

This being said, my use case is as follows: I have two apps, both using the same database as quite a lot of the data is shared between them and there was no reason to duplicate. The jobs queues are running on database connection. Both apps dispatch and process their own jobs on queues with different names. There is also a `default` queue which is used for processing emails and a few other bits.

Long story short: today I ran into the situation where jobs were failing at an alarming rate on one of the apps, with the following error (excerpt):

```
Exception: Job is incomplete class: 
{"__PHP_Incomplete_Class_Name":"Spatie\\SlackAlerts\\Jobs\\SendToSlackChannelJob","webhookUrl":"https:\/\/hooks.slack.com.... 
```

This seems to happen because the wrong app was processing a job that was found on the `default` queue.

So I needed to have a way to somehow tell Slack Alerts that the job needs to be dispatched on a different queue than `default` . 

The PR introduces a config option `slack-alerts.queue`, which gets its value from `SLACK_ALERT_QUEUE` in `.env` . 

At runtime, the queue can be changed by calling `onQueue()` method. 

Example:
```
 \Spatie\SlackAlerts\Facades\SlackAlert::onQueue('test')->message(":smile: :custom-code:")
```

