### PR TITLE
Add Set Icon and Username ability; add missing onQueue declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ SlackAlert::toChannel('subscription_alerts')->message("You have a new subscriber
 ```
 
 ## Queuing
-By default, messages are sent by dispatching the job to the `default` queue. 
+By default, messages are sent by dispatching the job to the `default` queue.
 
 ### Configuring the queue
 In `.env` file, add
@@ -181,6 +181,24 @@ use Spatie\SlackAlerts\Facades\SlackAlert;
 
 SlackAlert::message("A message that notifies <@username> and everyone else who is <!here>")
 
+```
+
+### Icon Change
+
+You can change the icon that appears next to the display-name at the top of the message.
+```php
+use Spatie\SlackAlerts\Facades\SlackAlert;
+
+SlackAlert::withIconURL('https://example.com/tiny-icon.jpg')->message("Some message.");
+```
+
+### Display Name Change
+
+You can change the Display-Name that appears next to the display-name at the top of the message.
+```php
+use Spatie\SlackAlerts\Facades\SlackAlert;
+
+SlackAlert::withUsername('More Descriptive Name')->message("Some message.");
 ```
 
 ### Usage in tests

--- a/src/Facades/SlackAlert.php
+++ b/src/Facades/SlackAlert.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Facade;
  * @method static self toChannel(string $text)
  * @method static void message(string $text)
  * @method static void blocks(array $blocks)
+ * @method static self withUsername(string $text)
+ * @method static self withIconURL(string $text)
+ * @method static self onQueue(string $text)
  *
  * @see \Spatie\SlackAlerts\SlackAlert
  */

--- a/src/Jobs/SendToSlackChannelJob.php
+++ b/src/Jobs/SendToSlackChannelJob.php
@@ -28,6 +28,8 @@ class SendToSlackChannelJob implements ShouldQueue
         public ?string $text = null,
         public ?array $blocks = null,
         public ?string $channel = null,
+        public ?string $username = null,
+        public ?string $icon_url = null,
     ) {
     }
 
@@ -39,6 +41,14 @@ class SendToSlackChannelJob implements ShouldQueue
 
         if ($this->channel) {
             $payload['channel'] = $this->channel;
+        }
+
+        if ($this->icon_url) {
+            $payload['icon_url'] = $this->icon_url;
+        }
+
+        if ($this->username) {
+            $payload['username'] = $this->username;
         }
 
         Http::post($this->webhookUrl, $payload)->throw();

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -44,7 +44,7 @@ class SlackAlert
 
     public function withIconURL(string $icon_url): self
     {
-        $this->$icon_url = $icon_url;
+        $this->icon_url = $icon_url;
 
         return $this;
     }

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -5,9 +5,14 @@ namespace Spatie\SlackAlerts;
 class SlackAlert
 {
     protected string $webhookUrlName = 'default';
+
     protected ?string $channel = null;
 
     protected ?string $queue = null;
+
+    protected ?string $username = null;
+
+    protected ?string $icon_url = null;
 
     public function to(string $webhookUrlName): self
     {
@@ -30,6 +35,20 @@ class SlackAlert
         return $this;
     }
 
+    public function withUsername(string $username): self
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    public function withIconURL(string $icon_url): self
+    {
+        $this->$icon_url = $icon_url;
+
+        return $this;
+    }
+
     public function message(string $text): void
     {
         $webhookUrl = Config::getWebhookUrl($this->webhookUrlName);
@@ -42,6 +61,8 @@ class SlackAlert
             'text' => $text,
             'webhookUrl' => $webhookUrl,
             'channel' => $this->channel,
+            'username' => $this->username,
+            'icon_url' => $this->icon_url,
         ]);
 
         dispatch(
@@ -61,6 +82,8 @@ class SlackAlert
             'blocks' => $blocks,
             'webhookUrl' => $webhookUrl,
             'channel' => $this->channel,
+            'username' => $this->username,
+            'icon_url' => $this->icon_url,
         ]);
 
         dispatch(

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -104,3 +104,15 @@ it('can send a message via a queue set at runtime ', function (string $queue) {
 })->with([
     'default', 'my-queue',
 ]);
+
+it('can send a message via a username set at runtime ', function () {
+    SlackAlert::withUsername('My New Name #1')->message('test-data');
+
+    Bus::assertDispatched(SendToSlackChannelJob::class);
+});
+
+it('can send a message via a icon_url set at runtime ', function () {
+    SlackAlert::withIconURL('https://www.example.com/icon.jpg')->message('test-data');
+
+    Bus::assertDispatched(SendToSlackChannelJob::class);
+});

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -106,12 +106,16 @@ it('can send a message via a queue set at runtime ', function (string $queue) {
 ]);
 
 it('can send a message via a username set at runtime ', function () {
+    config()->set('slack-alerts.webhook_urls.default', 'https://test-domain.com');
+
     SlackAlert::withUsername('My New Name #1')->message('test-data');
 
     Bus::assertDispatched(SendToSlackChannelJob::class);
 });
 
 it('can send a message via a icon_url set at runtime ', function () {
+    config()->set('slack-alerts.webhook_urls.default', 'https://test-domain.com');
+
     SlackAlert::withIconURL('https://www.example.com/icon.jpg')->message('test-data');
 
     Bus::assertDispatched(SendToSlackChannelJob::class);


### PR DESCRIPTION
I have the need to set the slack Display Name, and icon next to it, when my application posts into my alert channel; this code adds it, and updates the README for it.

It also adds a missing declaration for `onQueue` which was causing my IDE to not know that it was there.