### PR TITLE
Feature: added support of icon_emoji

### DIFF
--- a/src/Facades/SlackAlert.php
+++ b/src/Facades/SlackAlert.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void blocks(array $blocks)
  * @method static self withUsername(string $text)
  * @method static self withIconURL(string $text)
+ * @method static self withIconEmoji(string $text)
  * @method static self onQueue(string $text)
  *
  * @see \Spatie\SlackAlerts\SlackAlert

--- a/src/Jobs/SendToSlackChannelJob.php
+++ b/src/Jobs/SendToSlackChannelJob.php
@@ -30,6 +30,7 @@ class SendToSlackChannelJob implements ShouldQueue
         public ?string $channel = null,
         public ?string $username = null,
         public ?string $icon_url = null,
+        public ?string $icon_emoji = null,
     ) {
     }
 
@@ -45,6 +46,10 @@ class SendToSlackChannelJob implements ShouldQueue
 
         if ($this->icon_url) {
             $payload['icon_url'] = $this->icon_url;
+        }
+
+        if ($this->icon_emoji) {
+            $payload['icon_emoji'] = $this->icon_emoji;
         }
 
         if ($this->username) {

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -14,6 +14,8 @@ class SlackAlert
 
     protected ?string $icon_url = null;
 
+    protected ?string $icon_emoji = null;
+
     public function to(string $webhookUrlName): self
     {
         $this->webhookUrlName = $webhookUrlName;
@@ -49,6 +51,13 @@ class SlackAlert
         return $this;
     }
 
+    public function withIconEmoji(string $icon_emoji): self
+    {
+        $this->icon_emoji = $icon_emoji;
+
+        return $this;
+    }
+
     public function message(string $text): void
     {
         $webhookUrl = Config::getWebhookUrl($this->webhookUrlName);
@@ -63,6 +72,7 @@ class SlackAlert
             'channel' => $this->channel,
             'username' => $this->username,
             'icon_url' => $this->icon_url,
+            'icon_emoji' => $this->icon_emoji,
         ]);
 
         dispatch(
@@ -84,6 +94,7 @@ class SlackAlert
             'channel' => $this->channel,
             'username' => $this->username,
             'icon_url' => $this->icon_url,
+            'icon_emoji' => $this->icon_emoji,
         ]);
 
         dispatch(

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -120,3 +120,11 @@ it('can send a message via a icon_url set at runtime ', function () {
 
     Bus::assertDispatched(SendToSlackChannelJob::class);
 });
+
+it('can send a message via a icon_emoji set at runtime ', function () {
+    config()->set('slack-alerts.webhook_urls.default', 'https://test-domain.com');
+
+    SlackAlert::withIconEmoji(':heart:')->message('test-data');
+
+    Bus::assertDispatched(SendToSlackChannelJob::class);
+});


### PR DESCRIPTION
`Incoming Webhooks` integration in Slack allows to send `icon_emoji` option with an emoji code to use it as user avatar. I really lack this feature.