### PR TITLE
Enabled config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ This is the contents of the published config file:
 ```php
 return [
     /*
+     * Whether the slack alerts are enabled.
+     */
+    'enabled' => env('SLACK_ALERT_ENABLED', true),
+
+    /*
      * The webhook URLs that we'll use to send a message to Slack.
      */
     'webhook_urls' => [

--- a/config/slack-alerts.php
+++ b/config/slack-alerts.php
@@ -2,6 +2,11 @@
 
 return [
     /*
+     * Whether the slack alerts are enabled.
+     */
+    'enabled' => env('SLACK_ALERT_ENABLED', true),
+
+    /*
      * The webhook URLs that we'll use to send a message to Slack.
      */
     'webhook_urls' => [

--- a/src/Config.php
+++ b/src/Config.php
@@ -48,4 +48,9 @@ class Config
 
         return $queue;
     }
+
+    public static function isEnabled(): bool
+    {
+        return config('slack-alerts.enabled', true);
+    }
 }

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -62,7 +62,7 @@ class SlackAlert
     {
         $webhookUrl = Config::getWebhookUrl($this->webhookUrlName);
 
-        if (! $webhookUrl) {
+        if (!Config::isEnabled() || ! $webhookUrl) {
             return;
         }
 
@@ -84,7 +84,7 @@ class SlackAlert
     {
         $webhookUrl = Config::getWebhookUrl($this->webhookUrlName);
 
-        if (! $webhookUrl) {
+        if (!Config::isEnabled() || ! $webhookUrl) {
             return;
         }
 

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -68,7 +68,10 @@ it('will not send a message if the alerts are disabled', function () {
     config()->set('slack-alerts.enabled', false);
 
     SlackAlert::message('test-data');
-})->expectNotToPerformAssertions();
+    SlackAlert::blocks([]);
+
+    Bus::assertNotDispatched(SendToSlackChannelJob::class);
+});
 
 it('will throw an exception for an invalid webhook url', function () {
     config()->set('slack-alerts.webhook_urls.default', 'not-an-url');

--- a/tests/SlackAlertsTest.php
+++ b/tests/SlackAlertsTest.php
@@ -63,6 +63,13 @@ it('will not throw an exception for an empty webhook url', function () {
     SlackAlert::message('test-data');
 })->expectNotToPerformAssertions();
 
+it('will not send a message if the alerts are disabled', function () {
+    config()->set('slack-alerts.webhook_urls.default', 'https://test-domain.com');
+    config()->set('slack-alerts.enabled', false);
+
+    SlackAlert::message('test-data');
+})->expectNotToPerformAssertions();
+
 it('will throw an exception for an invalid webhook url', function () {
     config()->set('slack-alerts.webhook_urls.default', 'not-an-url');
 


### PR DESCRIPTION
Adds config option to disable Slack alerts even if the webhook URL is passed