### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,9 @@ jobs:
             testbench: ^11.0
           - laravel: 12.*
             testbench: ^10.0
+        exclude:
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [13.*, 12.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: ^11.0
           - laravel: 12.*
             testbench: ^10.0
-          - laravel: 11.*
-            testbench: ^9.0
-          - laravel: 10.*
-            testbench: ^8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -23,17 +23,17 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^12.0|^13.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^6.0|^7.0|^8.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^10.5|^11.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0",
+        "phpunit/phpunit": "^11.0|^12.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/src/SlackAlert.php
+++ b/src/SlackAlert.php
@@ -42,6 +42,7 @@ class SlackAlert
     public function sync(bool $sync = true): self
     {
         $this->sync = $sync;
+
         return $this;
     }
 
@@ -83,7 +84,7 @@ class SlackAlert
             $extraProperties,
         );
 
-        if (!Config::isEnabled() || empty($allProperties['webhookUrl'])) {
+        if (! Config::isEnabled() || empty($allProperties['webhookUrl'])) {
             return;
         }
 
@@ -94,6 +95,7 @@ class SlackAlert
             dispatch_sync(
                 $job->onQueue($this->queue())
             );
+
             return;
         }
 


### PR DESCRIPTION
## Summary

- Add Laravel 13 support, drop Laravel 10 and 11
- Update `illuminate/contracts` to `^12.0|^13.0`
- Update dev dependencies for compatibility: `orchestra/testbench`, `pestphp/pest`, `phpunit/phpunit`, `nunomaduro/collision`, and phpstan packages
- All existing tests pass on Laravel 13 with Pest 4