### PR TITLE
Document Slack incoming webhook override limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ use Spatie\SlackAlerts\Facades\SlackAlert;
 SlackAlert::toChannel('subscription_alerts')->message("You have a new subscriber to the {$newsletter->name} newsletter!");
 ```
 
+> **Note**: Slack incoming webhooks created for modern Slack apps do not allow per-message channel overrides. The message will always be delivered to the channel the webhook was installed for, regardless of the value passed to `toChannel`. This method only has an effect on legacy incoming webhooks. See the [Slack documentation](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/) for details. If you need per-channel routing, consider using the Slack Web API (`chat.postMessage` with a bot token) instead.
+
 ## Queuing
 
 By default, messages are sent by dispatching the job to the `default` queue.
@@ -204,6 +206,8 @@ use Spatie\SlackAlerts\Facades\SlackAlert;
 SlackAlert::withIconURL('https://example.com/tiny-icon.jpg')->message("Some message.");
 ```
 
+> **Note**: Like the channel override, Slack incoming webhooks for modern Slack apps silently ignore `withIconURL` and `withIconEmoji`. The icon configured on the Slack app will be used instead. See the [Slack documentation](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/) for details.
+
 ### Display Name Change
 
 You can change the Display-Name that appears next to the display-name at the top of the message.
@@ -213,6 +217,8 @@ use Spatie\SlackAlerts\Facades\SlackAlert;
 
 SlackAlert::withUsername('More Descriptive Name')->message("Some message.");
 ```
+
+> **Note**: Slack incoming webhooks for modern Slack apps silently ignore `withUsername`. The username configured on the Slack app will be used instead. See the [Slack documentation](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/) for details.
 
 ### Synchronous Dispatch
 


### PR DESCRIPTION
Fixes #75

## Summary

Issue #75 reports that `toChannel()` is silently ignored when using modern Slack incoming webhooks. This is correct, and confirmed by Slack's own documentation:

> You cannot override the default channel (chosen by the user who installed your app), username, or icon when you're using incoming webhooks to post messages.

Source: https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/

The same limitation applies to `withUsername()`, `withIconURL()`, and `withIconEmoji()`. Legacy incoming webhooks did support these overrides, but modern Slack apps do not.

## Why documentation only

The package cannot work around Slack's platform limitation. Removing the fields from the payload would break users still relying on legacy webhooks that do honor them. Detecting which type of webhook is in use from the URL alone is not reliable, so logging a warning or throwing an exception would produce false positives.

Documenting the limitation near each affected method is the least surprising fix, and matches the first suggestion in the issue.

## Changes

Added notes under these README sections pointing to Slack's documentation and, for channel routing, suggesting `chat.postMessage` with a bot token as an alternative:

- Sending message to an alternative channel
- Icon Change
- Display Name Change